### PR TITLE
Extract userID from token

### DIFF
--- a/server/src/controllers/resume.controller.js
+++ b/server/src/controllers/resume.controller.js
@@ -3,7 +3,7 @@ const catchAsync = require('../utils/catchAsync');
 const { resumeService } = require('../services');
 
 const saveExperience = catchAsync(async (req, res) => {
-  const missingFields = await resumeService.saveExperience(req.body);
+  const missingFields = await resumeService.saveExperience(req.body, req.user.id);
   res.status(httpStatus.CREATED).send(missingFields);
 });
 

--- a/server/src/services/resume.service.js
+++ b/server/src/services/resume.service.js
@@ -8,14 +8,17 @@ const ApiError = require('../utils/ApiError');
  * @param {Object} experienceBody
  * @returns {Promise<Object>}
  */
-const saveExperience = async (experienceBody) => {
-  // Check if we already saved experience for the user 
-  if (await RawExperience.RawExperience.userAlreadyHas(experienceBody.userId)) {
+const saveExperience = async (experienceBody, userId) => {
+  // Check if we already saved experience for the user
+  if (await RawExperience.RawExperience.userAlreadyHas(userId)) {
     throw new ApiError(httpStatus.BAD_REQUEST, 'User already has loaded experience');
   }
 
   // Save the raw experience (the text the user provided as input without any formatting)
-  RawExperience.RawExperience.create(experienceBody);
+  RawExperience.RawExperience.create({
+    experience: experienceBody.experience,
+    userId,
+  });
 
   // Use openAI adapter to extract from the experience the provided list of fields and also the list of the one not present in the experience
   const fields = OpenAIAdapter.openaiAdapter.extractExperienceFields(experienceBody.experience, [1,2]);
@@ -23,7 +26,7 @@ const saveExperience = async (experienceBody) => {
   // Save the formatted experience (the fields that gpt found from the text extracted and saved as JSON format)
   FormattedExperience.FormattedExperience.create({
     fields: fields.foundFields, 
-    userId: experienceBody.userId,
+    userId: userId,
   });
 
   // Return only the missing fields

--- a/server/src/validations/resume.validation.js
+++ b/server/src/validations/resume.validation.js
@@ -4,7 +4,6 @@ const saveExperience = {
   body: Joi.object()
     .keys({
       experience: Joi.string(),
-      userId: Joi.string(),
     })
     .min(1),
 };


### PR DESCRIPTION
Removed the userId fields from the body of the post experience request, and now gets the userId from the token.
Example of the new body JSON for POST experience

> {
    "experience": "text experience"
}